### PR TITLE
ci: skip screengrab tests in connectedAndroidTest

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -30,6 +30,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # pull_request_target defaults to the base branch; force PR head so PR
+          # changes are actually exercised.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -55,6 +59,17 @@ jobs:
           disable-animations: true
           script: bundle exec fastlane tests
 
+      - if: failure()
+        name: Print test failures
+        run: |
+          shopt -s globstar nullglob
+          for xml in app/build/outputs/androidTest-results/**/*.xml \
+                     app/build/test-results/**/*.xml; do
+            echo "::group::$xml"
+            cat "$xml"
+            echo "::endgroup::"
+          done
+
       - if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -62,6 +77,8 @@ jobs:
           path: |
             app/build/reports/tests/
             app/build/reports/androidTests/
+            app/build/outputs/androidTest-results/
+            app/build/test-results/
           if-no-files-found: ignore
 
   create-test-build:

--- a/app/src/androidTest/java/com/tien/piholeconnect/e2e/FilterRulesScreenE2ETest.kt
+++ b/app/src/androidTest/java/com/tien/piholeconnect/e2e/FilterRulesScreenE2ETest.kt
@@ -1,12 +1,15 @@
 package com.tien.piholeconnect.e2e
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onLast
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.tien.piholeconnect.fixtures.Fixtures
@@ -85,8 +88,21 @@ class FilterRulesScreenE2ETest : E2ETestBase() {
                     it.method == HttpMethod.Post && it.path.startsWith("/api/domains/")
                 }
             }
+            // The refresh appends the new row at the bottom of the LazyColumn; on
+            // shorter emulator screens it sits below the fold, which keeps it out
+            // of the semantics tree. Scroll the list to surface the row before
+            // asserting — performScrollToNode also waits for the refreshed list
+            // to compose, so this doubles as the "data has arrived" wait.
             composeRule.waitUntil(timeoutMillis = 10_000) {
-                composeRule.onAllNodes(hasText(newDomain)).fetchSemanticsNodes().isNotEmpty()
+                try {
+                    composeRule
+                        .onAllNodes(hasScrollAction())
+                        .onLast()
+                        .performScrollToNode(hasText(newDomain))
+                    true
+                } catch (_: Throwable) {
+                    false
+                }
             }
             composeRule.onNodeWithText(newDomain).assertIsDisplayed()
         }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,7 +30,14 @@ platform :android do # rubocop:disable Metrics/BlockLength
   desc 'Run JVM unit tests and instrumented tests (needs a running emulator/device).'
   lane :tests do
     gradle(task: 'test')
-    gradle(task: 'connectedAndroidTest')
+    # Exclude the screengrab-driven screenshot suite: it's only meant to run via the
+    # `screenshots` lane (fastlane screengrab CLI handles the locale/screenshot wiring).
+    # Running it under a plain connectedAndroidTest fails because the screengrab harness
+    # isn't set up.
+    gradle(
+      task: 'connectedAndroidTest',
+      flags: '-Pandroid.testInstrumentationRunnerArguments.notPackage=com.tien.piholeconnect.screenshot'
+    )
   end
 
   lane :screenshots do |options|


### PR DESCRIPTION
## Summary
- Exclude `com.tien.piholeconnect.screenshot` from the `tests` lane's `connectedAndroidTest` run. `PlayStoreScreenshots` is wired up for the screengrab CLI (`LocaleTestRule`, `UiAutomatorScreenshotStrategy`) and only works when driven through the `screenshots` lane.
- Force the `tests` job to checkout the PR head so `pull_request_target` actually exercises PR changes instead of the base branch.
- On failure, dump every JUnit `*.xml` from `androidTest-results/` and `test-results/` into the workflow log so the failing test + stack trace is visible inline next time.

## Test plan
- [ ] CI on this PR completes the `tests` job successfully
- [ ] If anything still fails, the failure section of the log now contains the JUnit XML pointing at the offending test method

Note: this is a speculative fix; if CI still fails, the dumped XML output will tell us which test is actually breaking.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVbv77vVeN9Uub5yBWZwKU)_