### PR TITLE
ci: generate release notes for GitHub releases and the Play Store

### DIFF
--- a/.github/prompts/play-store-release-notes.prompt.yml
+++ b/.github/prompts/play-store-release-notes.prompt.yml
@@ -1,0 +1,20 @@
+name: Play Store release notes
+description: User-facing "What's new" notes for the Pi-hole Connect Android app, in a given language.
+model: openai/gpt-4o
+modelParameters:
+  maxCompletionTokens: 300
+messages:
+  - role: system
+    content: |
+      You are writing the "What's new" notes shown to everyday users on the Google Play Store for the Pi-hole Connect Android app.
+
+      You will receive a list of code-change descriptions (conventional-commit subjects). Summarize ONLY what a normal user would notice: new features, visible improvements, and bug fixes.
+
+      Rules:
+      - Ignore purely technical changes: build, ci, test, refactor, style, chore, dependency bumps, and internal cleanups. If nothing is user-visible, output a single line: "Bug fixes and performance improvements."
+      - Plain, non-technical language. No code names, PR/issue numbers, or hashes.
+      - A few short bullet points, most important first.
+      - Hard limit: 500 characters total (Google Play requirement). Be brief.
+      - Write the notes entirely in {{language}}. Output only the notes, nothing else.
+  - role: user
+    content: "{{changes}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,18 @@ on:
         description: Version Name
         required: true
 
+permissions:
+  contents: write
+  models: read
+
 jobs:
   create-release:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags so we can diff against the last release tag
 
       - uses: actions/setup-java@v5
         with:
@@ -27,6 +33,52 @@ jobs:
       - name: Write keystore to file
         run: echo ${{ secrets.KEYSTORE_BASE64 }} | base64 --decode > $GITHUB_WORKSPACE/keystore.jks
 
+      - name: Collect changes since last release
+        run: |
+          PREV_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          git log "${PREV_TAG:+$PREV_TAG..}HEAD" --no-merges --pretty=format:'- %s' > changes.txt
+          echo "Changes since ${PREV_TAG:-start}:"; cat changes.txt
+
+      - name: Generate Play Store notes (English)
+        id: notes_en_us
+        uses: actions/ai-inference@v1
+        with:
+          prompt-file: .github/prompts/play-store-release-notes.prompt.yml
+          input: |
+            language: English
+          file_input: |
+            changes: changes.txt
+
+      - name: Generate Play Store notes (German)
+        id: notes_de_de
+        uses: actions/ai-inference@v1
+        with:
+          prompt-file: .github/prompts/play-store-release-notes.prompt.yml
+          input: |
+            language: German
+          file_input: |
+            changes: changes.txt
+
+      - name: Generate Play Store notes (Polish)
+        id: notes_pl_pl
+        uses: actions/ai-inference@v1
+        with:
+          prompt-file: .github/prompts/play-store-release-notes.prompt.yml
+          input: |
+            language: Polish
+          file_input: |
+            changes: changes.txt
+
+      - name: Generate Play Store notes (Romanian)
+        id: notes_ro
+        uses: actions/ai-inference@v1
+        with:
+          prompt-file: .github/prompts/play-store-release-notes.prompt.yml
+          input: |
+            language: Romanian
+          file_input: |
+            changes: changes.txt
+
       - run: bundle exec fastlane release
         env:
           SUPPLY_JSON_KEY_DATA: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS }}
@@ -39,3 +91,7 @@ jobs:
           FL_SET_GITHUB_RELEASE_TAG_NAME: v${{ github.event.inputs.versionName }}
           FL_SET_GITHUB_RELEASE_COMMITISH: ${{ github.sha }}
           VERSION_NAME: ${{ github.event.inputs.versionName }}
+          PLAY_RELEASE_NOTES_EN_US: ${{ steps.notes_en_us.outputs.response }}
+          PLAY_RELEASE_NOTES_DE_DE: ${{ steps.notes_de_de.outputs.response }}
+          PLAY_RELEASE_NOTES_PL_PL: ${{ steps.notes_pl_pl.outputs.response }}
+          PLAY_RELEASE_NOTES_RO: ${{ steps.notes_ro.outputs.response }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
 default_platform(:android)
 
 platform :android do # rubocop:disable Metrics/BlockLength
@@ -58,9 +60,11 @@ platform :android do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  lane :release do
+  lane :release do # rubocop:disable Metrics/BlockLength
+    version_code = google_play_track_version_codes(track: 'internal').max + 1
+
     android_set_version_code(
-      version_code: google_play_track_version_codes(track: 'internal').max + 1,
+      version_code: version_code,
       gradle_file: 'app/build.gradle.kts'
     )
     android_set_version_name(
@@ -68,10 +72,34 @@ platform :android do # rubocop:disable Metrics/BlockLength
       gradle_file: 'app/build.gradle.kts'
     )
 
+    # "What's new" notes set per locale by the release workflow; Google Play caps each at 500 characters.
+    {
+      'en-US' => 'PLAY_RELEASE_NOTES_EN_US',
+      'de-DE' => 'PLAY_RELEASE_NOTES_DE_DE',
+      'pl-PL' => 'PLAY_RELEASE_NOTES_PL_PL',
+      'ro' => 'PLAY_RELEASE_NOTES_RO'
+    }.each do |locale, env_var|
+      notes = ENV.fetch(env_var, '').strip
+      next if notes.empty?
+
+      dir = "fastlane/metadata/android/#{locale}/changelogs"
+      FileUtils.mkdir_p(dir)
+      File.write("#{dir}/#{version_code}.txt", notes[0, 500])
+    end
+
     gradle(task: 'clean bundleRelease', properties: properties)
-    upload_to_play_store(track: 'internal')
+    upload_to_play_store(
+      track: 'internal',
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true
+    )
 
     gradle(task: 'clean assembleRelease', properties: properties)
-    set_github_release(is_draft: true, upload_assets: [lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]])
+    set_github_release(
+      is_draft: true,
+      is_generate_release_notes: true,
+      upload_assets: [lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]]
+    )
   end
 end


### PR DESCRIPTION
## What

The `release` workflow created a draft GitHub release and uploaded to the Play Store internal track with **empty release notes on both surfaces**. This fills each, tailored to its audience:

| Surface | Audience | Source |
|---|---|---|
| **GitHub release body** | developers / repo browsers | GitHub's native auto-generated notes (merged PRs + contributors) — technical |
| **Play Store "What's new"** | end users (en-US, de-DE, pl-PL, ro) | [`actions/ai-inference`](https://github.com/actions/ai-inference) distilling the commit log — friendly, no technical noise |

## How

- **GitHub** — `set_github_release(is_generate_release_notes: true)` in the `release` lane; no `description` is passed, so the body is purely GitHub-generated.
- **Play Store** — a new step collects commit subjects since the last `v*` tag into `changes.txt`, then four `actions/ai-inference@v1` steps generate "What's new" notes (one per locale) from a shared prompt template (`.github/prompts/play-store-release-notes.prompt.yml`). Notes flow to fastlane via `PLAY_RELEASE_NOTES_*` env vars; the lane writes `fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt`, truncated to Google Play's 500-char cap.
- The prompt explicitly ignores `build`/`ci`/`test`/`refactor`/`style`/`chore`/dependency changes so end users aren't shown technical noise.

## Reviewer notes

- **Permissions**: adds a top-level `permissions:` block (`contents: write` for the release, `models: read` for GitHub Models). GitHub Models must be enabled for the repo.
- **Play Store locales**: `supply` rejects a changelog for a locale that isn't an *active* listing language. If `de-DE`/`pl-PL`/`ro` aren't active, drop that locale's ai-inference step + the Fastfile map entry (`en-US` is the safe baseline).
- **Checkout**: `fetch-depth: 0` is required so `git describe` / the `tag..HEAD` range work — don't shallow it.
- Verified locally: `ruby -c`, `rubocop`, and YAML parsing of the workflow + prompt template all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)