### PR TITLE
fix: upload generated Play Store release notes to internal track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,11 @@ local.properties
 # deliver temporary files
 **/fastlane/Preview.html
 
-# snapshot generated screenshots
+# fastlane metadata is generated (screengrab screenshots + per-release
+# changelogs), so it stays ignored. The .gitkeep keeps the directory present at
+# checkout so `supply` auto-detects metadata_path before any action runs.
 **/fastlane/metadata/android/**
+!**/fastlane/metadata/android/.gitkeep
 
 # scan temporary files
 **/fastlane/test_output


### PR DESCRIPTION
## What

Commit an empty `fastlane/metadata/android/.gitkeep` (and carve it out of the blanket metadata ignore) so the directory exists at checkout. No code changes.

## Why

The `Release` workflow generates per-locale "What's new" notes and writes them to `fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt`, but `supply` never uploaded them — the AAB published to the internal track with no release notes.

Root cause is a memoization + eager-evaluation trap in `supply`:

- `supply`'s `metadata_path` default is an **eagerly-evaluated glob** — `(Dir["./fastlane/metadata/android"] + Dir["./metadata"]).first` — baked into a **process-wide memoized** options array (`@options ||= [...]`).
- The `release` lane calls `google_play_track_version_codes` **first**, which is itself a `supply` action. That call memoizes the options array — and thus freezes `metadata_path` — *before* the lane creates the changelog directory.
- The directory doesn't exist at that moment (it's also gitignored, so never present at checkout), so `metadata_path` resolves to `nil`. `supply`'s `perform_upload_meta` is guarded by `... && metadata_path`, so the **entire changelog-upload phase is skipped** even though the `.txt` files were written. The AAB upload is unaffected — hence "publishes, but no notes."

Note: `skip_upload_metadata: true` in the lane is *not* the cause — `supply` explicitly excludes changelogs from that flag (`skip_upload_changelogs` is separate and defaults to `false`).

## The fix

Make the directory exist before any `supply` action runs, by committing a `.gitkeep` marker. The eager glob then resolves to the real path on first memoization, and `upload_to_play_store` finds and uploads the generated changelogs.

- The **actual per-release notes stay generated and gitignored** — only the empty directory marker is tracked. Nothing mutable is committed.
- No Fastfile or workflow change; the default auto-detection now works as `supply` intends.

## Reviewer notes

- `.gitignore` + `.gitkeep` are both required: Git can't track empty directories (hence the marker), and the marker would be swallowed by the existing `**/fastlane/metadata/android/**` rule without the `!…/.gitkeep` negation.
- Trade-off: there is no committed fallback changelog, so if the AI step returns blank for a locale, the lane's existing `next if notes.empty?` simply skips it — that locale's "What's new" stays unchanged for the release (the AAB still ships).
- Verified: `.gitkeep` tracks; generated `<code>.txt` and screengrab `images/` remain ignored; `git add` stages only `.gitignore` + `.gitkeep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)