### PR TITLE
fix(ci): point screengrab at the Hilt instrumentation runner

### DIFF
--- a/fastlane/Screengrabfile
+++ b/fastlane/Screengrabfile
@@ -1,3 +1,4 @@
 app_apk_path('app/build/outputs/apk/debug/app-debug.apk')
 tests_apk_path('app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk')
 clear_previous_screenshots(true)
+test_instrumentation_runner('com.tien.piholeconnect.HiltTestRunner')


### PR DESCRIPTION
The app declares testInstrumentationRunner = com.tien.piholeconnect.HiltTestRunner,
so the androidTest APK only registers that instrumentation. screengrab defaulted
to androidx.test.runner.AndroidJUnitRunner, so the release workflow's screenshot
job failed with:

  Unable to find instrumentation info for
  ComponentInfo{com.tien.piholeconnect.test/androidx.test.runner.AndroidJUnitRunner}

Set test_instrumentation_runner in the Screengrabfile so am instrument targets the
runner the test APK actually exposes.