### PR TITLE
fix(test): wait for home screen chart animation before screengrab

### DIFF
--- a/app/src/androidTest/java/com/tien/piholeconnect/screenshot/PlayStoreScreenshots.kt
+++ b/app/src/androidTest/java/com/tien/piholeconnect/screenshot/PlayStoreScreenshots.kt
@@ -35,7 +35,12 @@ class PlayStoreScreenshots {
                 adsBlockingEnabled = true,
             )
         composeTestRule.setContent { ScreenshotHomeScreen(viewModel = viewModel) }
-        composeTestRule.mainClock.advanceTimeBy(2000)
+        composeTestRule.waitForIdle()
+        // The dashboard chart animates in from an empty state (Vico plays the data load as an
+        // animated transition) and Screengrab captures the real device surface, so advancing the
+        // virtual test clock doesn't settle what's drawn. Sleep on the real frame clock to let the
+        // animation finish before grabbing the screenshot.
+        Thread.sleep(2000)
         composeTestRule.waitForIdle()
         Screengrab.screenshot("1_home")
     }


### PR DESCRIPTION
## What

The home screen Play Store screenshot was capturing the dashboard chart **mid-animation** (still filling in from an empty state). This swaps the ineffective virtual-clock advance for a real wall-clock delay so the animation settles before the screenshot is grabbed.

## Why

`PlayStoreScreenshots.homeScreen()` relied on `composeTestRule.mainClock.advanceTimeBy(2000)`, which only moves Compose's **virtual** test clock. But:

- `Screengrab` uses `UiAutomatorScreenshotStrategy`, which captures the **real device surface** pixels.
- The chart's entry transition is played by Vico via `modelProducer.runTransaction { }` (`ui/component/Chart.kt`), and that animation isn't a tracked Compose idling resource — so `waitForIdle()` returned before the on-screen animation had finished rendering.

Net result: the captured image showed the graph partway through its fill-from-empty animation.

## How

`createComposeRule()` defaults to `autoAdvance = true`, so the UI thread keeps drawing real frames. Sleeping the test thread on the real frame clock lets both the Vico chart transition and the `animateIntAsState` stat counters settle before capture:

```kotlin
composeTestRule.setContent { ScreenshotHomeScreen(viewModel = viewModel) }
composeTestRule.waitForIdle()
Thread.sleep(2000)
composeTestRule.waitForIdle()
Screengrab.screenshot("1_home")
```

## Notes for reviewers

- Only the `homeScreen` test is affected — the statistics / filter rules / log / tools screens render lists with no entry animations, so they don't need the delay.
- `./gradlew spotlessCheck` passes.
