### PR TITLE
Surface app password guidance for Pi-hole 2FA on connection screen

### DIFF
--- a/app/src/main/java/com/tien/piholeconnect/ui/screen/piholeconnection/PiHoleConnectionScreen.kt
+++ b/app/src/main/java/com/tien/piholeconnect/ui/screen/piholeconnection/PiHoleConnectionScreen.kt
@@ -13,22 +13,29 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RichTooltip
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -54,6 +61,7 @@ import io.ktor.http.URLProtocol.Companion.HTTP
 import io.ktor.http.URLProtocol.Companion.HTTPS
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PiHoleConnectionScreen(
     navController: NavController,
@@ -65,6 +73,8 @@ fun PiHoleConnectionScreen(
     val scrollState = rememberScrollState()
     var isDeleteAlertDialogExpanded by rememberSaveable { mutableStateOf(false) }
     val focusManager = LocalFocusManager.current
+    val appPasswordTooltipState = rememberTooltipState(isPersistent = true)
+    val scope = rememberCoroutineScope()
     val nextActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) })
     val doneActions = KeyboardActions(onDone = { focusManager.clearFocus() })
 
@@ -191,7 +201,38 @@ fun PiHoleConnectionScreen(
             value = viewModel.password,
             onValueChange = { viewModel.password = it },
             visualTransformation = PasswordVisualTransformation(),
-            supportingText = { Text(stringResource(R.string.pi_hole_connection_hint_scanner)) },
+            supportingText = { Text(stringResource(R.string.pi_hole_connection_hint_password)) },
+            trailingIcon = {
+                TooltipBox(
+                    positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
+                    tooltip = {
+                        RichTooltip(
+                            title = {
+                                Text(
+                                    stringResource(
+                                        R.string.pi_hole_connection_app_password_tooltip_title
+                                    )
+                                )
+                            }
+                        ) {
+                            Text(
+                                stringResource(
+                                    R.string.pi_hole_connection_app_password_tooltip_text
+                                )
+                            )
+                        }
+                    },
+                    state = appPasswordTooltipState,
+                ) {
+                    IconButton(onClick = { scope.launch { appPasswordTooltipState.show() } }) {
+                        Icon(
+                            Icons.Outlined.Info,
+                            contentDescription =
+                                stringResource(R.string.pi_hole_connection_app_password_info),
+                        )
+                    }
+                }
+            },
             singleLine = true,
             keyboardOptions =
                 KeyboardOptions(

--- a/app/src/main/java/com/tien/piholeconnect/ui/screen/piholeconnection/PiHoleConnectionScreen.kt
+++ b/app/src/main/java/com/tien/piholeconnect/ui/screen/piholeconnection/PiHoleConnectionScreen.kt
@@ -61,7 +61,6 @@ import io.ktor.http.URLProtocol.Companion.HTTP
 import io.ktor.http.URLProtocol.Companion.HTTPS
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PiHoleConnectionScreen(
     navController: NavController,
@@ -73,8 +72,6 @@ fun PiHoleConnectionScreen(
     val scrollState = rememberScrollState()
     var isDeleteAlertDialogExpanded by rememberSaveable { mutableStateOf(false) }
     val focusManager = LocalFocusManager.current
-    val appPasswordTooltipState = rememberTooltipState(isPersistent = true)
-    val scope = rememberCoroutineScope()
     val nextActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) })
     val doneActions = KeyboardActions(onDone = { focusManager.clearFocus() })
 
@@ -203,35 +200,12 @@ fun PiHoleConnectionScreen(
             visualTransformation = PasswordVisualTransformation(),
             supportingText = { Text(stringResource(R.string.pi_hole_connection_hint_password)) },
             trailingIcon = {
-                TooltipBox(
-                    positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
-                    tooltip = {
-                        RichTooltip(
-                            title = {
-                                Text(
-                                    stringResource(
-                                        R.string.pi_hole_connection_app_password_tooltip_title
-                                    )
-                                )
-                            }
-                        ) {
-                            Text(
-                                stringResource(
-                                    R.string.pi_hole_connection_app_password_tooltip_text
-                                )
-                            )
-                        }
-                    },
-                    state = appPasswordTooltipState,
-                ) {
-                    IconButton(onClick = { scope.launch { appPasswordTooltipState.show() } }) {
-                        Icon(
-                            Icons.Outlined.Info,
-                            contentDescription =
-                                stringResource(R.string.pi_hole_connection_app_password_info),
-                        )
-                    }
-                }
+                InfoTooltipIcon(
+                    title = stringResource(R.string.pi_hole_connection_app_password_tooltip_title),
+                    text = stringResource(R.string.pi_hole_connection_app_password_tooltip_text),
+                    contentDescription =
+                        stringResource(R.string.pi_hole_connection_app_password_info),
+                )
             },
             singleLine = true,
             keyboardOptions =
@@ -324,6 +298,22 @@ fun PiHoleConnectionScreen(
             ) {
                 Text(stringResource(R.string.pi_hole_connection_remove))
             }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun InfoTooltipIcon(title: String, text: String, contentDescription: String) {
+    val tooltipState = rememberTooltipState(isPersistent = true)
+    val scope = rememberCoroutineScope()
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
+        tooltip = { RichTooltip(title = { Text(title) }) { Text(text) } },
+        state = tooltipState,
+    ) {
+        IconButton(onClick = { scope.launch { tooltipState.show() } }) {
+            Icon(Icons.Outlined.Info, contentDescription = contentDescription)
         }
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -66,9 +66,12 @@
     <string name="log_screen_status">Status</string>
     <string name="options_menu_bug_report">Fehler melden</string>
     <string name="options_menu_web_dashboard">WEB-Dashboard</string>
+    <string name="pi_hole_connection_app_password_info">Über App-Passwörter</string>
+    <string name="pi_hole_connection_app_password_tooltip_text"><![CDATA[Wenn du 2FA für dein Pi-hole aktiviert hast, gib hier ein App-Passwort anstelle deines normalen Passworts ein. Erstelle eines in der Pi-hole-Weboberfläche unter Settings > Web interface / API.]]></string>
+    <string name="pi_hole_connection_app_password_tooltip_title">Zwei-Faktor-Authentifizierung aktiv?</string>
     <string name="pi_hole_connection_desc_scanner">QR-Code scannen</string>
     <string name="pi_hole_connection_error_host_required">Host ist erforderlich</string>
-    <string name="pi_hole_connection_hint_scanner"><![CDATA[Dies ist in \"Settings > API / Web Interface > Show API token\" zu finden]]></string>
+    <string name="pi_hole_connection_hint_password">Das Passwort deiner Pi-hole-Weboberfläche</string>
     <string name="pi_hole_connection_label_api_path">API-Pfad</string>
     <string name="pi_hole_connection_label_basic_auth_password">Basisauthentifizierung Passwort</string>
     <string name="pi_hole_connection_label_basic_auth_realm">Basisauthentifizierung Realm</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -70,9 +70,12 @@
     <string name="log_screen_status">Status</string>
     <string name="options_menu_bug_report">Zgłoś problem</string>
     <string name="options_menu_web_dashboard">Panel internetowy</string>
+    <string name="pi_hole_connection_app_password_info">Informacje o hasłach aplikacji</string>
+    <string name="pi_hole_connection_app_password_tooltip_text"><![CDATA[Jeśli włączyłeś 2FA w swoim Pi-hole, wprowadź tutaj hasło aplikacji zamiast zwykłego hasła. Wygeneruj je w interfejsie sieciowym Pi-hole w sekcji Settings > Web interface / API.]]></string>
+    <string name="pi_hole_connection_app_password_tooltip_title">Używasz uwierzytelniania dwuskładnikowego?</string>
     <string name="pi_hole_connection_desc_scanner">Zeskanuj kod QR</string>
     <string name="pi_hole_connection_error_host_required">Host jest wymagany</string>
-    <string name="pi_hole_connection_hint_scanner"><![CDATA[Można to znaleźć w \"Ustawienia > API / Interfejs sieciowy > Pokaż token API"]]></string>
+    <string name="pi_hole_connection_hint_password">Hasło do interfejsu sieciowego Pi-hole</string>
     <string name="pi_hole_connection_label_api_path">Ścieżka interfejsu API</string>
     <string name="pi_hole_connection_label_basic_auth_password">Podstawowe hasło uwierzytelniające</string>
     <string name="pi_hole_connection_label_basic_auth_realm">Podstawowa przestrzeń uwierzytelniania</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -68,9 +68,12 @@
     <string name="log_screen_status">Stare</string>
     <string name="options_menu_bug_report">Reportează problemă</string>
     <string name="options_menu_web_dashboard">Tablou de bord</string>
+    <string name="pi_hole_connection_app_password_info">Despre parolele de aplicație</string>
+    <string name="pi_hole_connection_app_password_tooltip_text"><![CDATA[Dacă ai activat 2FA pe Pi-hole, introdu aici o parolă de aplicație în locul parolei obișnuite. Generează una în interfața web Pi-hole la Settings > Web interface / API.]]></string>
+    <string name="pi_hole_connection_app_password_tooltip_title">Folosești autentificarea în doi pași?</string>
     <string name="pi_hole_connection_desc_scanner">Scanează cod QR</string>
     <string name="pi_hole_connection_error_host_required">Gazda este obligatorie</string>
-    <string name="pi_hole_connection_hint_scanner"><![CDATA[Poate fi găsit la \"Setări > API / Interfață Web > Arată cheia API\"]]></string>
+    <string name="pi_hole_connection_hint_password">Parola interfeței web Pi-hole</string>
     <string name="pi_hole_connection_label_api_path">Cale API</string>
     <string name="pi_hole_connection_label_basic_auth_password">Parola de autentificare de bază</string>
     <string name="pi_hole_connection_label_basic_auth_realm">Domeniu pentru autentificare de bază</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,9 +68,12 @@
     <string name="log_screen_status">Status</string>
     <string name="options_menu_bug_report">Report issue</string>
     <string name="options_menu_web_dashboard">Web dashboard</string>
+    <string name="pi_hole_connection_app_password_info">About app passwords</string>
+    <string name="pi_hole_connection_app_password_tooltip_text"><![CDATA[If you\'ve enabled 2FA on your Pi-hole, enter an app password here instead of your regular password. Generate one in the Pi-hole web interface under Settings > Web interface / API.]]></string>
+    <string name="pi_hole_connection_app_password_tooltip_title">Using two-factor authentication?</string>
     <string name="pi_hole_connection_desc_scanner">Scan QR code</string>
     <string name="pi_hole_connection_error_host_required">Host is required</string>
-    <string name="pi_hole_connection_hint_scanner"><![CDATA[This can be found at \"Settings > API / Web Interface > Show API token\"]]></string>
+    <string name="pi_hole_connection_hint_password">Your Pi-hole web interface password</string>
     <string name="pi_hole_connection_label_api_path">API Path</string>
     <string name="pi_hole_connection_label_basic_auth_password">Basic Auth password</string>
     <string name="pi_hole_connection_label_basic_auth_realm">Basic Auth realm</string>


### PR DESCRIPTION
Add a trailing info icon with an M3 RichTooltip to the password field
explaining that an app password should be used instead of the regular
password when 2FA is enabled. Replace the outdated Pi-hole v5 API-token
QR hint with accurate v6 password supporting text. Add and localize the
new strings (en, de, pl, ro) and remove the unused scanner hint.