### PR TITLE
fix: re-enabling blocking sends empty request body

### DIFF
--- a/app/src/androidTest/java/com/tien/piholeconnect/e2e/HomeScreenE2ETest.kt
+++ b/app/src/androidTest/java/com/tien/piholeconnect/e2e/HomeScreenE2ETest.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.tien.piholeconnect.fixtures.Fixtures
+import com.tien.piholeconnect.fixtures.respondJson
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.ktor.http.HttpMethod
 import org.junit.Test
@@ -65,6 +67,42 @@ class HomeScreenE2ETest : E2ETestBase() {
             }
             assert("\"timer\":300" in postedBody) {
                 "expected timer=300 (5 minutes) in POST body; got: $postedBody"
+            }
+        }
+    }
+
+    @Test
+    fun toggleBlocking_enablePiHole_callsDnsControlApiWithBlockingTrue() {
+        // Start with blocking DISABLED so the FAB offers "Enable blocking".
+        mockResponses.onGet("/api/dns/blocking") { respondJson(Fixtures.blockingDisabledJson) }
+        launchApp().use {
+            composeRule.waitUntil(timeoutMillis = 15_000) {
+                composeRule
+                    .onAllNodesWithContentDescription("Enable blocking")
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+            composeRule.onNodeWithContentDescription("Enable blocking").performClick()
+
+            composeRule.waitUntil(timeoutMillis = 5_000) {
+                composeRule.onAllNodes(hasText("ENABLE")).fetchSemanticsNodes().isNotEmpty()
+            }
+            composeRule.onNodeWithText("ENABLE").performClick()
+
+            composeRule.waitUntil(timeoutMillis = 5_000) {
+                mockResponses.recorded.any {
+                    it.method == HttpMethod.Post && it.path == "/api/dns/blocking"
+                }
+            }
+            val postedBody =
+                mockResponses.recorded
+                    .first { it.method == HttpMethod.Post && it.path == "/api/dns/blocking" }
+                    .bodyText
+            // Regression guard: Pi-hole's schema wrongly marks `blocking` as `default: true`
+            // (the server does not treat an omitted field as "enable"), so without encodeDefaults
+            // the body serializes to `{}` and never re-enables blocking.
+            assert("\"blocking\":true" in postedBody) {
+                "expected POST body to enable blocking; got: $postedBody"
             }
         }
     }

--- a/app/src/main/java/com/tien/piholeconnect/model/PiHoleSerializer.kt
+++ b/app/src/main/java/com/tien/piholeconnect/model/PiHoleSerializer.kt
@@ -9,6 +9,14 @@ class PiHoleSerializer {
             ignoreUnknownKeys = true
             allowSpecialFloatingPointValues = true
             useArrayPolymorphism = false
+            // Pi-hole's published OpenAPI schema declares `default: true` on
+            // SetBlockingRequest.blocking, but the server does NOT treat an omitted field as
+            // "enable" — so `blocking = true` must be sent explicitly. Without encodeDefaults,
+            // kotlinx drops values equal to that bogus default and re-enabling POSTs an empty `{}`.
+            encodeDefaults = true
+            // Keep null fields omitted so enabling encodeDefaults doesn't spray explicit
+            // nulls into every request body across the generated client.
+            explicitNulls = false
         }
     }
 }


### PR DESCRIPTION
## Problem

Re-enabling DNS blocking from the Home screen silently does nothing, while disabling works fine.

## Root cause

This is a bug in **Pi-hole's published OpenAPI schema**, which the app's API client is generated from at build time. The schema marks `SetBlockingRequest.blocking` with `default: true`, but the FTL server does **not** treat an omitted field as "enable".

The chain:
1. The OpenAPI generator turns the schema's `default: true` into a Kotlin default parameter value (`blocking: Boolean? = true`).
2. kotlinx serialization (with `encodeDefaults` off, the default) drops any property whose value equals its default.
3. So `enable()` → `SetBlockingRequest(blocking = true, timer = null)` serialized to an empty `{}`, and the server did nothing.

Disabling kept working because `blocking = false` differs from the default and was always serialized.

## Fix

In `PiHoleSerializer.DefaultJson`:
- `encodeDefaults = true` — `blocking` is now always sent explicitly (`{"blocking":true}`).
- `explicitNulls = false` — keep null fields omitted, so the change doesn't spray explicit `null`s across every generated request body.

## Test

Added `HomeScreenE2ETest.toggleBlocking_enablePiHole_callsDnsControlApiWithBlockingTrue`, which starts with blocking disabled, taps Enable, and asserts the POST body contains `"blocking":true`. Before the fix the body was `{}`, so this guards the regression. Mirrors the existing disable-body test.

## Verification

- `./gradlew spotlessApply` — clean
- `:app:compileDebugKotlin` — compiles
- `:app:compileDebugAndroidTestKotlin` — compiles
- Instrumented test not executed here (needs a device/emulator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)